### PR TITLE
CACS Issue 12

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -259,7 +259,7 @@ question: |
 subquestion: |
   If this civil action involves contract claims, provide a description of those claims and the total dollar value of the claims. Otherwise, skip this question. 
 fields:
-  - 'Total contract claims': total_contract_claims
+  - 'Dollar value of contract claims': total_contract_claims
     datatype: currency
     required: False
     help: |


### PR DESCRIPTION
PR fixes the change included in Issue #12 :  Modify language of `Page id: contract claims` to alleviate potential confusion of this question:
- change "Total contract claims" to "Dollar value of contract claims." 

Closes Issue #12 