### PR TITLE
Language fix: CACS Issue 20

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -225,8 +225,6 @@ objects:
 id: representation
 question: |
   Representation
-subquestion: |
-  Placeholder text
 fields:
   - Are you an attorney?: is_attorney
     datatype: yesnoradio


### PR DESCRIPTION
Remove the words "placeholder text" from page id: representation.

Closes Issue #20 