### PR TITLE
Issue #26: Fixed language on contract claims

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -268,12 +268,13 @@ fields:
 ---
 id: contract claims
 question: |
-  Does this action involve contract claims?
+  Contract claims
 subquestion: |
-  If this civil action involves contract claims, provide a description of those claims and the total dollar value of the claims. Otherwise, skip this question. 
+  Provide a brief description of the contract claims and their total dollar value. Round claim amounts to the nearest dollar. 
 fields:
   - 'Dollar value of contract claims': total_contract_claims
     datatype: currency
+    step: 1
     required: False
     help: |
       Provide instructions on calculating contact claims.


### PR DESCRIPTION
`Page id: contract claims`: 
- fixed language to remove question of whether or not there are contract claims since question only appears if user selects 'contract claims' checkbox. 
- also added reminder to round amounts to nearest dollar.

Closes Issue #26  