### PR TITLE
Stop any other users question triggering

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -775,6 +775,7 @@ code: |
 id: interview_order_Civil_Action_Cover_Sheet0026
 code: |
   user_role = "plaintiff"
+  users.there_is_another = False
   basic_questions_intro_screen 
   # Set the preferred/allowed courts for this interview
   preferred_court = interview_metadata["Civil_Action_Cover_Sheet0026"]["preferred court"]


### PR DESCRIPTION
Ran two informal tests (user = attorney representing plaintiff and user = pro se plaintiff). Confirm that the question asking for other users does not get triggered.

Closes issue 21.