### PR TITLE
Fix related actions question

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -414,7 +414,7 @@ comment: |
         show if: has_related_actions
 ---
 code: |
-  related_actions_description = comma_and_list([action.case_name + ", " + action.docket_number + ", " + action.court_county for action in related_actions])
+  related_actions_description = comma_and_list([action.docket_number + ", " + action.case_name + ", " + action.court_county for action in related_actions])
 ---
 id: questions pertaining to case
 question: |
@@ -765,7 +765,7 @@ attachment:
       - "total_contract_claims": ${ f'{int(round(total_contract_claims)):,}' }
       - "description_of_claim": ${ description_of_claim }
       - "user_signature_date": ${ users[0].signature_date }
-      - "related_actions": ${ related_actions_description }
+      - "related_actions": ${ comma_and_list([action.docket_number + ", " + action.case_name + ", " + action.court_county for action in related_actions]) }
       - "certification_signature_date": ${ certification_signature_date }
       - "certification_signature": ${ certification_signature }
 ---
@@ -878,5 +878,5 @@ attachment:
       - "total_contract_claims": ${ f'{int(round(total_contract_claims)):,}' }
       - "description_of_claim": ${ description_of_claim }
       - "user_signature_date": ${ users[0].signature_date }
-      - "related_actions": ${ related_actions_description }
+      - "related_actions": ${ comma_and_list([action.docket_number + ", " + action.case_name + ", " + action.court_county for action in related_actions]) }
       - "certification_signature_date": ${ certification_signature_date }

--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -413,9 +413,6 @@ comment: |
       required: False
         show if: has_related_actions
 ---
-code: |
-  related_actions_description = comma_and_list([action.docket_number + ", " + action.case_name + ", " + action.court_county for action in related_actions])
----
 id: questions pertaining to case
 question: |
   Pertaining to your case

--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -383,14 +383,14 @@ id: related actions
 question: |
   Tell the court about any related actions pending in the Superior Court
 subquestion: |  
-  If you need to add more, click ${word("Add another")}.
+  If you need to add more, click ${word("add another")}.
 list collect: True
 fields:
+  - Docket number: related_actions[i].docket_number
+    required: False
+  - Case name: related_actions[i].case_name
+    required: False
   - Court county: related_actions[i].court_county
-    required: False
-  - Name of case: related_actions[i].case_name
-    required: False
-  - Docket number of case: related_actions[i].docket_number
     required: False
 ---
 comment: |


### PR DESCRIPTION
- Bring code into attachment blocks to get `related_actions_description` to print in pdf
- Fix related actions fields order to bring in line with order on PDF (case number, case name, and county) and simplify field names

Closes issue #5 