### PR TITLE
Fix signature date behavior

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -264,6 +264,7 @@ fields:
         You cannot continue unless you check this box.
   - 'Date of certification': certification_signature_date
     datatype: date
+    default: ${today().format("yyyy-MM-dd")}
 ---
 id: contract claims
 question: |

--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -262,6 +262,8 @@ fields:
     validation messages:
       minlength: |
         You cannot continue unless you check this box.
+  - 'Date of certification': certification_signature_date
+    datatype: date
 ---
 id: contract claims
 question: |
@@ -439,8 +441,6 @@ subquestion: |
   Show ${ showifdef('related_actions_description') }
 fields:
   - 'Date of user signature': users[0].signature_date
-    datatype: date
-  - 'Date of certification signature': certification_signature_date
     datatype: date
 ---
 id: action and track designation

--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -262,9 +262,9 @@ fields:
     validation messages:
       minlength: |
         You cannot continue unless you check this box.
-  - 'Date of certification': certification_signature_date
-    datatype: date
-    default: ${today().format("yyyy-MM-dd")}
+# - 'Date of certification': certification_signature_date
+#   datatype: date
+#   default: ${today().format("yyyy-MM-dd")}
 ---
 id: contract claims
 question: |
@@ -434,15 +434,14 @@ fields:
   - There are other actions related to this case: has_related_actions
     datatype: yesnowide
 ---
-id: signature dates
-question: |
-  Signature dates to do
-subquestion: |
-  Placeholder text
-  Show ${ showifdef('related_actions_description') }
-fields:
-  - 'Date of user signature': users[0].signature_date
-    datatype: date
+#id: signature dates
+#question: |
+#  Signature dates to do
+#subquestion: |
+#  Placeholder text
+#fields:
+#  - 'Date of user signature': users[0].signature_date
+#    datatype: date
 ---
 id: action and track designation
 question: |
@@ -756,10 +755,11 @@ attachment:
       - "collection_of_debt_yes": ${ collection_of_debt_yes }
       - "total_contract_claims": ${ f'{int(round(total_contract_claims)):,}' }
       - "description_of_claim": ${ description_of_claim }
-      - "user_signature_date": ${ users[0].signature_date }
+      - "user_signature_date": ${ signature_date }
+      - "user_signature": ${ users[0].signature }
       - "related_actions": ${ related_actions_description }
-      - "certification_signature_date": ${ certification_signature_date }
-      - "certification_signature": ${ certification_signature }
+      - "certification_signature_date": ${ signature_date if is_representing_plaintiff else '' }
+      - "certification_signature": ${ users[0].signature if is_representing_plaintiff else '' }
 ---
 code: |
   interview_short_title = "File a Cover Sheet for your Superior Court civil action"
@@ -792,7 +792,6 @@ code: |
   if has_related_actions:
     related_actions.gather()
   documented_medical_expenses_total
-  users[0].signature_date
   str(plaintiffs[0])
   courts[0].address.county
   str(defendants[0])
@@ -801,6 +800,7 @@ code: |
   # Comment out the line below if you don't want this behavior. 
   # mark_unfilled_fields_empty(interview_metadata["Civil_Action_Cover_Sheet0026"])
   Civil_Action_Cover_Sheet0026_preview_question # Pre-canned preview screen
+  signature_date
   signature_fields = ['certification_signature', 'users[0].signature']
   basic_questions_signature_flow
   users[0].signature
@@ -868,6 +868,6 @@ attachment:
       - "collection_of_debt_yes": ${ collection_of_debt_yes }
       - "total_contract_claims": ${ f'{int(round(total_contract_claims)):,}' }
       - "description_of_claim": ${ description_of_claim }
-      - "user_signature_date": ${ users[0].signature_date }
+      - "user_signature_date": ${ signature_date }
       - "related_actions": ${ related_actions_description }
-      - "certification_signature_date": ${ certification_signature_date }
+      - "certification_signature_date": ${ signature_date if is_representing_plaintiff else '' }


### PR DESCRIPTION
Signature date only asked once, regardless of path. 
- If attorney, date prints to signature and certification signature blocks
- If pro se, date prints only to signature block

Closes issue #13 