### PR TITLE
Interview now asks for Plaintiff's address

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -841,6 +841,7 @@ code: |
     agrees_to_certify
     attorney.name.first
     attorney.address.address
+  users[0].address.address
   defendants[0].address.address
   jury_claim_made_yes
   code_number


### PR DESCRIPTION
Interview asks for Plaintiff's address when plaintiff is represented by an attorney:
- Address requested
- Automatic court selector chooses appropriate court based on plaintiff address
- Address populates into PDF