### PR TITLE
Remove step and add min value to currency datatypes

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -333,8 +333,8 @@ subquestion: |
   Provide a brief description of the contract claims and their total dollar value. Round claim amounts to the nearest dollar. 
 fields:
   - 'Dollar value of contract claims': total_contract_claims
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       Provide instructions on calculating contact claims.
@@ -372,8 +372,8 @@ subquestion: |
  Round expenses to the nearest dollar. 
 fields:
   - 'Other documented damages': documented_damages
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       Insert help text that descibes other documented damages.
@@ -527,26 +527,26 @@ question: |
   What are the other damages? Round expenses to the nearest dollar. 
 fields:
   - 'Documented lost wages and compensation': documented_lost_wages
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       Insert help text that explains lost wages and compensation.
   - 'Documented property damages': documented_property_damages
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       Insert help text that describes property damages.
   - 'Anticipated future medical expenses': anticipated_future_medical_expenses
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       Provide details on how to calculate this number.
   - 'Anticipated lost wages': anticipated_lost_wages
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       Provide details on how to calculate this amount.
@@ -576,32 +576,32 @@ subquestion: |
   Enter the total amount, in dollars, of documented medical expenses incurred in connection with this claim. 
 fields:
   - 'Hospital expenses': documented_medical_expenses_hospital
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       You can include all expenses incurred with a hospital visit, like emergency room charges, supplies, overnight stays, etc. Do not include expenses that were charged by your doctor or ambulance company, chiropractor, or physical therapist (they are covered separately). Round expenses to the nearest dollar. 
   - 'Doctor expenses': documented_medical_expenses_doctor
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       You can include all costs related to doctor visits. Do not include expenses that were charged by chiropractors, physical therapists, or other providers (they are covered separately).
   - 'Chiropractic expenses': documented_medical_expenses_chiropractic
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       You can include all costs related to chiropractor visits. Do not include expenses that were charged by doctors, physical therapists, or other providers (they are covered separately).
   - 'Physical therapy expenses': documented_medical_expenses_physical_therapy
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       You can include all expenses related to physical therapy. Do not include expenses that were charged by your hospital, ambulance company, chiropractor, or doctor (they are covered separately).
   - 'Other documented medical expenses': documented_medical_expenses_other
-    datatype: currency(decimals=False)
-    step: 1
+    datatype: currency
+    min: 0
     required: False
     help: |
       Include all documented medical expenses incurred in connection with this claim that have not been provided in the hospital, doctor, chiropractor, or physical therapy sections.


### PR DESCRIPTION
In this commit I also removed `datatype: currency(decimals=False)` because it was not in the appropriate place. I do not yet know where the appropriate place is.

