### PR TITLE
Override other party name basic question

### DIFF
--- a/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/CivilActionCoverSheet/data/questions/Civil_Action_Cover_Sheet.yml
@@ -326,6 +326,35 @@ fields:
   - Zip: attorney.address.zip
     required: False
 ---
+id: names of opposing party
+question: |
+  Who is the **defendant** or **respondent** in this case?
+fields:
+  - Is the defendant or respondent a person or a business?: other_parties[i].person_type
+    input type: radio
+    choices:
+      - Business or organization: business
+      - Person: individual
+  - First name: other_parties[i].name.first
+    show if:
+      variable: other_parties[i].person_type
+      is: "individual"
+  - Last name: other_parties[i].name.last
+    show if:
+      variable: other_parties[i].person_type      
+      is: "individual"
+  - Suffix: other_parties[i].name.suffix
+    code: |
+      name_suffix()
+    show if:
+      variable: other_parties[i].person_type      
+      is: "individual"
+    required: False      
+  - Name of organization or business: other_parties[i].name.first
+    show if:
+      variable: other_parties[i].person_type
+      is: business
+---
 id: contract claims
 question: |
   Contract claims


### PR DESCRIPTION
I pulled in the other parties name question from basic questions to override asking for more than one question.

MVP we only want one defendant to be asked, post-MVP we may include the option to add more than one defendant.

Tested all the way through to final pdf on the following:
- User = attorney
- User = pro se

@LGG233 what do you think of the language and bold? This was how it was in the basic questions, not sure about the bold though. It's your call! If we go for bold, we should then bold the other name questions.